### PR TITLE
Add missing Ubuntu os-release fixtures

### DIFF
--- a/tests/data/distro/os-release/ubuntu/ubuntu-12.04.txt
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-12.04.txt
@@ -1,0 +1,6 @@
+NAME="Ubuntu"
+VERSION="12.04.5 LTS, Precise Pangolin"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu precise (12.04.5 LTS)"
+VERSION_ID="12.04"

--- a/tests/data/distro/os-release/ubuntu/ubuntu-12.04.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-12.04.txt-expected.json
@@ -1,0 +1,8 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "12.04.5 LTS, Precise Pangolin",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu precise (12.04.5 LTS)",
+  "VERSION_ID": "12.04"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-12.10.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-12.10.txt-expected.json
@@ -1,0 +1,8 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "12.10, Quantal Quetzal",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu quantal (12.10)",
+  "VERSION_ID": "12.10"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-13.04.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-13.04.txt-expected.json
@@ -1,0 +1,11 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "13.04, Raring Ringtail",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 13.04",
+  "VERSION_ID": "13.04",
+  "HOME_URL": "http://www.ubuntu.com/",
+  "SUPPORT_URL": "http://help.ubuntu.com/",
+  "BUG_REPORT_URL": "http://bugs.launchpad.net/ubuntu/"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-13.10.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-13.10.txt-expected.json
@@ -1,0 +1,11 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "13.10, Saucy Salamander",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 13.10",
+  "VERSION_ID": "13.10",
+  "HOME_URL": "http://www.ubuntu.com/",
+  "SUPPORT_URL": "http://help.ubuntu.com/",
+  "BUG_REPORT_URL": "http://bugs.launchpad.net/ubuntu/"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-14.04.txt
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-14.04.txt
@@ -1,0 +1,9 @@
+NAME="Ubuntu"
+VERSION="14.04.4 LTS, Trusty Tahr"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 14.04.4 LTS"
+VERSION_ID="14.04"
+HOME_URL="http://www.ubuntu.com/"
+SUPPORT_URL="http://help.ubuntu.com/"
+BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"

--- a/tests/data/distro/os-release/ubuntu/ubuntu-14.04.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-14.04.txt-expected.json
@@ -1,0 +1,11 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "14.04.4 LTS, Trusty Tahr",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 14.04.4 LTS",
+  "VERSION_ID": "14.04",
+  "HOME_URL": "http://www.ubuntu.com/",
+  "SUPPORT_URL": "http://help.ubuntu.com/",
+  "BUG_REPORT_URL": "http://bugs.launchpad.net/ubuntu/"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-14.10.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-14.10.txt-expected.json
@@ -1,0 +1,11 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "14.10 (Utopic Unicorn)",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 14.10",
+  "VERSION_ID": "14.10",
+  "HOME_URL": "http://www.ubuntu.com/",
+  "SUPPORT_URL": "http://help.ubuntu.com/",
+  "BUG_REPORT_URL": "http://bugs.launchpad.net/ubuntu/"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-15.04.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-15.04.txt-expected.json
@@ -1,0 +1,11 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "15.04 (Vivid Vervet)",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 15.04",
+  "VERSION_ID": "15.04",
+  "HOME_URL": "http://www.ubuntu.com/",
+  "SUPPORT_URL": "http://help.ubuntu.com/",
+  "BUG_REPORT_URL": "http://bugs.launchpad.net/ubuntu/"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-15.10.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-15.10.txt-expected.json
@@ -1,0 +1,11 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "15.10 (Wily Werewolf)",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 15.10",
+  "VERSION_ID": "15.10",
+  "HOME_URL": "http://www.ubuntu.com/",
+  "SUPPORT_URL": "http://help.ubuntu.com/",
+  "BUG_REPORT_URL": "http://bugs.launchpad.net/ubuntu/"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-16.04.txt
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-16.04.txt
@@ -1,0 +1,10 @@
+NAME="Ubuntu"
+VERSION="16.04 LTS (Xenial Xerus)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 16.04 LTS"
+VERSION_ID="16.04"
+HOME_URL="http://www.ubuntu.com/"
+SUPPORT_URL="http://help.ubuntu.com/"
+BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
+UBUNTU_CODENAME=xenial

--- a/tests/data/distro/os-release/ubuntu/ubuntu-16.04.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-16.04.txt-expected.json
@@ -1,0 +1,12 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "16.04 LTS (Xenial Xerus)",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 16.04 LTS",
+  "VERSION_ID": "16.04",
+  "HOME_URL": "http://www.ubuntu.com/",
+  "SUPPORT_URL": "http://help.ubuntu.com/",
+  "BUG_REPORT_URL": "http://bugs.launchpad.net/ubuntu/",
+  "UBUNTU_CODENAME": "xenial"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-16.10.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-16.10.txt-expected.json
@@ -1,0 +1,14 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "16.10 (Yakkety Yak)",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 16.10",
+  "VERSION_ID": "16.10",
+  "HOME_URL": "http://www.ubuntu.com/",
+  "SUPPORT_URL": "http://help.ubuntu.com/",
+  "BUG_REPORT_URL": "http://bugs.launchpad.net/ubuntu/",
+  "PRIVACY_POLICY_URL": "http://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "VERSION_CODENAME": "yakkety",
+  "UBUNTU_CODENAME": "yakkety"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-17.04.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-17.04.txt-expected.json
@@ -1,0 +1,14 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "17.04 (Zesty Zapus)",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 17.04",
+  "VERSION_ID": "17.04",
+  "HOME_URL": "https://www.ubuntu.com/",
+  "SUPPORT_URL": "https://help.ubuntu.com/",
+  "BUG_REPORT_URL": "https://bugs.launchpad.net/ubuntu/",
+  "PRIVACY_POLICY_URL": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "VERSION_CODENAME": "zesty",
+  "UBUNTU_CODENAME": "zesty"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-17.10.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-17.10.txt-expected.json
@@ -1,0 +1,14 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "17.10 (Artful Aardvark)",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 17.10",
+  "VERSION_ID": "17.10",
+  "HOME_URL": "https://www.ubuntu.com/",
+  "SUPPORT_URL": "https://help.ubuntu.com/",
+  "BUG_REPORT_URL": "https://bugs.launchpad.net/ubuntu/",
+  "PRIVACY_POLICY_URL": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "VERSION_CODENAME": "artful",
+  "UBUNTU_CODENAME": "artful"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-18.04.txt
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-18.04.txt
@@ -1,0 +1,12 @@
+NAME="Ubuntu"
+VERSION="18.04 LTS (Bionic Beaver)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 18.04 LTS"
+VERSION_ID="18.04"
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+VERSION_CODENAME=bionic
+UBUNTU_CODENAME=bionic

--- a/tests/data/distro/os-release/ubuntu/ubuntu-18.04.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-18.04.txt-expected.json
@@ -1,0 +1,14 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "18.04 LTS (Bionic Beaver)",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 18.04 LTS",
+  "VERSION_ID": "18.04",
+  "HOME_URL": "https://www.ubuntu.com/",
+  "SUPPORT_URL": "https://help.ubuntu.com/",
+  "BUG_REPORT_URL": "https://bugs.launchpad.net/ubuntu/",
+  "PRIVACY_POLICY_URL": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "VERSION_CODENAME": "bionic",
+  "UBUNTU_CODENAME": "bionic"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-18.10.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-18.10.txt-expected.json
@@ -1,0 +1,14 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "18.10 (Cosmic Cuttlefish)",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 18.10",
+  "VERSION_ID": "18.10",
+  "HOME_URL": "https://www.ubuntu.com/",
+  "SUPPORT_URL": "https://help.ubuntu.com/",
+  "BUG_REPORT_URL": "https://bugs.launchpad.net/ubuntu/",
+  "PRIVACY_POLICY_URL": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "VERSION_CODENAME": "cosmic",
+  "UBUNTU_CODENAME": "cosmic"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-19.04.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-19.04.txt-expected.json
@@ -1,0 +1,14 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "19.04 (Disco Dingo)",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 19.04",
+  "VERSION_ID": "19.04",
+  "HOME_URL": "https://www.ubuntu.com/",
+  "SUPPORT_URL": "https://help.ubuntu.com/",
+  "BUG_REPORT_URL": "https://bugs.launchpad.net/ubuntu/",
+  "PRIVACY_POLICY_URL": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "VERSION_CODENAME": "disco",
+  "UBUNTU_CODENAME": "disco"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-19.10.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-19.10.txt-expected.json
@@ -1,0 +1,14 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "19.10 (Eoan Ermine)",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 19.10",
+  "VERSION_ID": "19.10",
+  "HOME_URL": "https://www.ubuntu.com/",
+  "SUPPORT_URL": "https://help.ubuntu.com/",
+  "BUG_REPORT_URL": "https://bugs.launchpad.net/ubuntu/",
+  "PRIVACY_POLICY_URL": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "VERSION_CODENAME": "eoan",
+  "UBUNTU_CODENAME": "eoan"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-20.04.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-20.04.txt-expected.json
@@ -1,0 +1,14 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "20.04 LTS (Focal Fossa)",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 20.04 LTS",
+  "VERSION_ID": "20.04",
+  "HOME_URL": "https://www.ubuntu.com/",
+  "SUPPORT_URL": "https://help.ubuntu.com/",
+  "BUG_REPORT_URL": "https://bugs.launchpad.net/ubuntu/",
+  "PRIVACY_POLICY_URL": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "VERSION_CODENAME": "focal",
+  "UBUNTU_CODENAME": "focal"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-20.10.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-20.10.txt-expected.json
@@ -1,0 +1,14 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "20.10 (Groovy Gorilla)",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 20.10",
+  "VERSION_ID": "20.10",
+  "HOME_URL": "https://www.ubuntu.com/",
+  "SUPPORT_URL": "https://help.ubuntu.com/",
+  "BUG_REPORT_URL": "https://bugs.launchpad.net/ubuntu/",
+  "PRIVACY_POLICY_URL": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "VERSION_CODENAME": "groovy",
+  "UBUNTU_CODENAME": "groovy"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-21.04.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-21.04.txt-expected.json
@@ -1,0 +1,14 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "21.04 (Hirsute Hippo)",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 21.04",
+  "VERSION_ID": "21.04",
+  "HOME_URL": "https://www.ubuntu.com/",
+  "SUPPORT_URL": "https://help.ubuntu.com/",
+  "BUG_REPORT_URL": "https://bugs.launchpad.net/ubuntu/",
+  "PRIVACY_POLICY_URL": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "VERSION_CODENAME": "hirsute",
+  "UBUNTU_CODENAME": "hirsute"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-21.10.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-21.10.txt-expected.json
@@ -1,0 +1,14 @@
+{
+  "PRETTY_NAME": "Ubuntu 21.10",
+  "NAME": "Ubuntu",
+  "VERSION_ID": "21.10",
+  "VERSION": "21.10 (Impish Indri)",
+  "VERSION_CODENAME": "impish",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "HOME_URL": "https://www.ubuntu.com/",
+  "SUPPORT_URL": "https://help.ubuntu.com/",
+  "BUG_REPORT_URL": "https://bugs.launchpad.net/ubuntu/",
+  "PRIVACY_POLICY_URL": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "UBUNTU_CODENAME": "impish"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-artful.txt-distro-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-artful.txt-distro-expected.json
@@ -1,0 +1,24 @@
+{
+  "os": "linux",
+  "architecture": null,
+  "name": "Ubuntu",
+  "version": "17.10 (Artful Aardvark)",
+  "identifier": "ubuntu",
+  "id_like": "debian",
+  "version_codename": "artful",
+  "version_id": "17.10",
+  "pretty_name": "Ubuntu 17.10",
+  "cpe_name": null,
+  "home_url": "https://www.ubuntu.com/",
+  "documentation_url": null,
+  "support_url": "https://help.ubuntu.com/",
+  "bug_report_url": "https://bugs.launchpad.net/ubuntu/",
+  "privacy_policy_url": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "build_id": null,
+  "variant": null,
+  "variant_id": null,
+  "logo": null,
+  "extra_data": {
+    "UBUNTU_CODENAME": "artful"
+  }
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-artful.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-artful.txt-expected.json
@@ -1,0 +1,14 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "17.10 (Artful Aardvark)",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 17.10",
+  "VERSION_ID": "17.10",
+  "HOME_URL": "https://www.ubuntu.com/",
+  "SUPPORT_URL": "https://help.ubuntu.com/",
+  "BUG_REPORT_URL": "https://bugs.launchpad.net/ubuntu/",
+  "PRIVACY_POLICY_URL": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "VERSION_CODENAME": "artful",
+  "UBUNTU_CODENAME": "artful"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-bionic.txt-distro-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-bionic.txt-distro-expected.json
@@ -1,0 +1,24 @@
+{
+  "os": "linux",
+  "architecture": null,
+  "name": "Ubuntu",
+  "version": "18.04 LTS (Bionic Beaver)",
+  "identifier": "ubuntu",
+  "id_like": "debian",
+  "version_codename": "bionic",
+  "version_id": "18.04",
+  "pretty_name": "Ubuntu 18.04 LTS",
+  "cpe_name": null,
+  "home_url": "https://www.ubuntu.com/",
+  "documentation_url": null,
+  "support_url": "https://help.ubuntu.com/",
+  "bug_report_url": "https://bugs.launchpad.net/ubuntu/",
+  "privacy_policy_url": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "build_id": null,
+  "variant": null,
+  "variant_id": null,
+  "logo": null,
+  "extra_data": {
+    "UBUNTU_CODENAME": "bionic"
+  }
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-bionic.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-bionic.txt-expected.json
@@ -1,0 +1,14 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "18.04 LTS (Bionic Beaver)",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 18.04 LTS",
+  "VERSION_ID": "18.04",
+  "HOME_URL": "https://www.ubuntu.com/",
+  "SUPPORT_URL": "https://help.ubuntu.com/",
+  "BUG_REPORT_URL": "https://bugs.launchpad.net/ubuntu/",
+  "PRIVACY_POLICY_URL": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "VERSION_CODENAME": "bionic",
+  "UBUNTU_CODENAME": "bionic"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-cosmic.txt-distro-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-cosmic.txt-distro-expected.json
@@ -1,0 +1,24 @@
+{
+  "os": "linux",
+  "architecture": null,
+  "name": "Ubuntu",
+  "version": "18.10 (Cosmic Cuttlefish)",
+  "identifier": "ubuntu",
+  "id_like": "debian",
+  "version_codename": "cosmic",
+  "version_id": "18.10",
+  "pretty_name": "Ubuntu 18.10",
+  "cpe_name": null,
+  "home_url": "https://www.ubuntu.com/",
+  "documentation_url": null,
+  "support_url": "https://help.ubuntu.com/",
+  "bug_report_url": "https://bugs.launchpad.net/ubuntu/",
+  "privacy_policy_url": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "build_id": null,
+  "variant": null,
+  "variant_id": null,
+  "logo": null,
+  "extra_data": {
+    "UBUNTU_CODENAME": "cosmic"
+  }
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-cosmic.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-cosmic.txt-expected.json
@@ -1,0 +1,14 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "18.10 (Cosmic Cuttlefish)",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 18.10",
+  "VERSION_ID": "18.10",
+  "HOME_URL": "https://www.ubuntu.com/",
+  "SUPPORT_URL": "https://help.ubuntu.com/",
+  "BUG_REPORT_URL": "https://bugs.launchpad.net/ubuntu/",
+  "PRIVACY_POLICY_URL": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "VERSION_CODENAME": "cosmic",
+  "UBUNTU_CODENAME": "cosmic"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-disco.txt-distro-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-disco.txt-distro-expected.json
@@ -1,0 +1,24 @@
+{
+  "os": "linux",
+  "architecture": null,
+  "name": "Ubuntu",
+  "version": "19.04 (Disco Dingo)",
+  "identifier": "ubuntu",
+  "id_like": "debian",
+  "version_codename": "disco",
+  "version_id": "19.04",
+  "pretty_name": "Ubuntu 19.04",
+  "cpe_name": null,
+  "home_url": "https://www.ubuntu.com/",
+  "documentation_url": null,
+  "support_url": "https://help.ubuntu.com/",
+  "bug_report_url": "https://bugs.launchpad.net/ubuntu/",
+  "privacy_policy_url": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "build_id": null,
+  "variant": null,
+  "variant_id": null,
+  "logo": null,
+  "extra_data": {
+    "UBUNTU_CODENAME": "disco"
+  }
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-disco.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-disco.txt-expected.json
@@ -1,0 +1,14 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "19.04 (Disco Dingo)",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 19.04",
+  "VERSION_ID": "19.04",
+  "HOME_URL": "https://www.ubuntu.com/",
+  "SUPPORT_URL": "https://help.ubuntu.com/",
+  "BUG_REPORT_URL": "https://bugs.launchpad.net/ubuntu/",
+  "PRIVACY_POLICY_URL": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "VERSION_CODENAME": "disco",
+  "UBUNTU_CODENAME": "disco"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-eoan.txt-distro-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-eoan.txt-distro-expected.json
@@ -1,0 +1,24 @@
+{
+  "os": "linux",
+  "architecture": null,
+  "name": "Ubuntu",
+  "version": "19.10 (Eoan Ermine)",
+  "identifier": "ubuntu",
+  "id_like": "debian",
+  "version_codename": "eoan",
+  "version_id": "19.10",
+  "pretty_name": "Ubuntu 19.10",
+  "cpe_name": null,
+  "home_url": "https://www.ubuntu.com/",
+  "documentation_url": null,
+  "support_url": "https://help.ubuntu.com/",
+  "bug_report_url": "https://bugs.launchpad.net/ubuntu/",
+  "privacy_policy_url": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "build_id": null,
+  "variant": null,
+  "variant_id": null,
+  "logo": null,
+  "extra_data": {
+    "UBUNTU_CODENAME": "eoan"
+  }
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-eoan.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-eoan.txt-expected.json
@@ -1,0 +1,14 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "19.10 (Eoan Ermine)",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 19.10",
+  "VERSION_ID": "19.10",
+  "HOME_URL": "https://www.ubuntu.com/",
+  "SUPPORT_URL": "https://help.ubuntu.com/",
+  "BUG_REPORT_URL": "https://bugs.launchpad.net/ubuntu/",
+  "PRIVACY_POLICY_URL": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "VERSION_CODENAME": "eoan",
+  "UBUNTU_CODENAME": "eoan"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-focal.txt-distro-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-focal.txt-distro-expected.json
@@ -1,0 +1,24 @@
+{
+  "os": "linux",
+  "architecture": null,
+  "name": "Ubuntu",
+  "version": "20.04 LTS (Focal Fossa)",
+  "identifier": "ubuntu",
+  "id_like": "debian",
+  "version_codename": "focal",
+  "version_id": "20.04",
+  "pretty_name": "Ubuntu 20.04 LTS",
+  "cpe_name": null,
+  "home_url": "https://www.ubuntu.com/",
+  "documentation_url": null,
+  "support_url": "https://help.ubuntu.com/",
+  "bug_report_url": "https://bugs.launchpad.net/ubuntu/",
+  "privacy_policy_url": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "build_id": null,
+  "variant": null,
+  "variant_id": null,
+  "logo": null,
+  "extra_data": {
+    "UBUNTU_CODENAME": "focal"
+  }
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-focal.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-focal.txt-expected.json
@@ -1,0 +1,14 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "20.04 LTS (Focal Fossa)",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 20.04 LTS",
+  "VERSION_ID": "20.04",
+  "HOME_URL": "https://www.ubuntu.com/",
+  "SUPPORT_URL": "https://help.ubuntu.com/",
+  "BUG_REPORT_URL": "https://bugs.launchpad.net/ubuntu/",
+  "PRIVACY_POLICY_URL": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "VERSION_CODENAME": "focal",
+  "UBUNTU_CODENAME": "focal"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-groovy.txt-distro-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-groovy.txt-distro-expected.json
@@ -1,0 +1,24 @@
+{
+  "os": "linux",
+  "architecture": null,
+  "name": "Ubuntu",
+  "version": "20.10 (Groovy Gorilla)",
+  "identifier": "ubuntu",
+  "id_like": "debian",
+  "version_codename": "groovy",
+  "version_id": "20.10",
+  "pretty_name": "Ubuntu 20.10",
+  "cpe_name": null,
+  "home_url": "https://www.ubuntu.com/",
+  "documentation_url": null,
+  "support_url": "https://help.ubuntu.com/",
+  "bug_report_url": "https://bugs.launchpad.net/ubuntu/",
+  "privacy_policy_url": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "build_id": null,
+  "variant": null,
+  "variant_id": null,
+  "logo": null,
+  "extra_data": {
+    "UBUNTU_CODENAME": "groovy"
+  }
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-groovy.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-groovy.txt-expected.json
@@ -1,0 +1,14 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "20.10 (Groovy Gorilla)",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 20.10",
+  "VERSION_ID": "20.10",
+  "HOME_URL": "https://www.ubuntu.com/",
+  "SUPPORT_URL": "https://help.ubuntu.com/",
+  "BUG_REPORT_URL": "https://bugs.launchpad.net/ubuntu/",
+  "PRIVACY_POLICY_URL": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "VERSION_CODENAME": "groovy",
+  "UBUNTU_CODENAME": "groovy"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-hirsute.txt-distro-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-hirsute.txt-distro-expected.json
@@ -1,0 +1,24 @@
+{
+  "os": "linux",
+  "architecture": null,
+  "name": "Ubuntu",
+  "version": "21.04 (Hirsute Hippo)",
+  "identifier": "ubuntu",
+  "id_like": "debian",
+  "version_codename": "hirsute",
+  "version_id": "21.04",
+  "pretty_name": "Ubuntu 21.04",
+  "cpe_name": null,
+  "home_url": "https://www.ubuntu.com/",
+  "documentation_url": null,
+  "support_url": "https://help.ubuntu.com/",
+  "bug_report_url": "https://bugs.launchpad.net/ubuntu/",
+  "privacy_policy_url": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "build_id": null,
+  "variant": null,
+  "variant_id": null,
+  "logo": null,
+  "extra_data": {
+    "UBUNTU_CODENAME": "hirsute"
+  }
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-hirsute.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-hirsute.txt-expected.json
@@ -1,0 +1,14 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "21.04 (Hirsute Hippo)",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 21.04",
+  "VERSION_ID": "21.04",
+  "HOME_URL": "https://www.ubuntu.com/",
+  "SUPPORT_URL": "https://help.ubuntu.com/",
+  "BUG_REPORT_URL": "https://bugs.launchpad.net/ubuntu/",
+  "PRIVACY_POLICY_URL": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "VERSION_CODENAME": "hirsute",
+  "UBUNTU_CODENAME": "hirsute"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-impish.txt-distro-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-impish.txt-distro-expected.json
@@ -1,0 +1,24 @@
+{
+  "os": "linux",
+  "architecture": null,
+  "name": "Ubuntu",
+  "version": "21.10 (Impish Indri)",
+  "identifier": "ubuntu",
+  "id_like": "debian",
+  "version_codename": "impish",
+  "version_id": "21.10",
+  "pretty_name": "Ubuntu 21.10",
+  "cpe_name": null,
+  "home_url": "https://www.ubuntu.com/",
+  "documentation_url": null,
+  "support_url": "https://help.ubuntu.com/",
+  "bug_report_url": "https://bugs.launchpad.net/ubuntu/",
+  "privacy_policy_url": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "build_id": null,
+  "variant": null,
+  "variant_id": null,
+  "logo": null,
+  "extra_data": {
+    "UBUNTU_CODENAME": "impish"
+  }
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-impish.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-impish.txt-expected.json
@@ -1,0 +1,14 @@
+{
+  "PRETTY_NAME": "Ubuntu 21.10",
+  "NAME": "Ubuntu",
+  "VERSION_ID": "21.10",
+  "VERSION": "21.10 (Impish Indri)",
+  "VERSION_CODENAME": "impish",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "HOME_URL": "https://www.ubuntu.com/",
+  "SUPPORT_URL": "https://help.ubuntu.com/",
+  "BUG_REPORT_URL": "https://bugs.launchpad.net/ubuntu/",
+  "PRIVACY_POLICY_URL": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "UBUNTU_CODENAME": "impish"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-precise.txt-distro-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-precise.txt-distro-expected.json
@@ -1,0 +1,22 @@
+{
+  "os": "linux",
+  "architecture": null,
+  "name": "Ubuntu",
+  "version": "12.04.5 LTS, Precise Pangolin",
+  "identifier": "ubuntu",
+  "id_like": "debian",
+  "version_codename": null,
+  "version_id": "12.04",
+  "pretty_name": "Ubuntu precise (12.04.5 LTS)",
+  "cpe_name": null,
+  "home_url": null,
+  "documentation_url": null,
+  "support_url": null,
+  "bug_report_url": null,
+  "privacy_policy_url": null,
+  "build_id": null,
+  "variant": null,
+  "variant_id": null,
+  "logo": null,
+  "extra_data": {}
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-precise.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-precise.txt-expected.json
@@ -1,0 +1,8 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "12.04.5 LTS, Precise Pangolin",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu precise (12.04.5 LTS)",
+  "VERSION_ID": "12.04"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-quantal.txt-distro-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-quantal.txt-distro-expected.json
@@ -1,0 +1,22 @@
+{
+  "os": "linux",
+  "architecture": null,
+  "name": "Ubuntu",
+  "version": "12.10, Quantal Quetzal",
+  "identifier": "ubuntu",
+  "id_like": "debian",
+  "version_codename": null,
+  "version_id": "12.10",
+  "pretty_name": "Ubuntu quantal (12.10)",
+  "cpe_name": null,
+  "home_url": null,
+  "documentation_url": null,
+  "support_url": null,
+  "bug_report_url": null,
+  "privacy_policy_url": null,
+  "build_id": null,
+  "variant": null,
+  "variant_id": null,
+  "logo": null,
+  "extra_data": {}
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-quantal.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-quantal.txt-expected.json
@@ -1,0 +1,8 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "12.10, Quantal Quetzal",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu quantal (12.10)",
+  "VERSION_ID": "12.10"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-raring.txt-distro-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-raring.txt-distro-expected.json
@@ -1,0 +1,22 @@
+{
+  "os": "linux",
+  "architecture": null,
+  "name": "Ubuntu",
+  "version": "13.04, Raring Ringtail",
+  "identifier": "ubuntu",
+  "id_like": "debian",
+  "version_codename": null,
+  "version_id": "13.04",
+  "pretty_name": "Ubuntu 13.04",
+  "cpe_name": null,
+  "home_url": "http://www.ubuntu.com/",
+  "documentation_url": null,
+  "support_url": "http://help.ubuntu.com/",
+  "bug_report_url": "http://bugs.launchpad.net/ubuntu/",
+  "privacy_policy_url": null,
+  "build_id": null,
+  "variant": null,
+  "variant_id": null,
+  "logo": null,
+  "extra_data": {}
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-raring.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-raring.txt-expected.json
@@ -1,0 +1,11 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "13.04, Raring Ringtail",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 13.04",
+  "VERSION_ID": "13.04",
+  "HOME_URL": "http://www.ubuntu.com/",
+  "SUPPORT_URL": "http://help.ubuntu.com/",
+  "BUG_REPORT_URL": "http://bugs.launchpad.net/ubuntu/"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-saucy.txt-distro-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-saucy.txt-distro-expected.json
@@ -1,0 +1,22 @@
+{
+  "os": "linux",
+  "architecture": null,
+  "name": "Ubuntu",
+  "version": "13.10, Saucy Salamander",
+  "identifier": "ubuntu",
+  "id_like": "debian",
+  "version_codename": null,
+  "version_id": "13.10",
+  "pretty_name": "Ubuntu 13.10",
+  "cpe_name": null,
+  "home_url": "http://www.ubuntu.com/",
+  "documentation_url": null,
+  "support_url": "http://help.ubuntu.com/",
+  "bug_report_url": "http://bugs.launchpad.net/ubuntu/",
+  "privacy_policy_url": null,
+  "build_id": null,
+  "variant": null,
+  "variant_id": null,
+  "logo": null,
+  "extra_data": {}
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-saucy.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-saucy.txt-expected.json
@@ -1,0 +1,11 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "13.10, Saucy Salamander",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 13.10",
+  "VERSION_ID": "13.10",
+  "HOME_URL": "http://www.ubuntu.com/",
+  "SUPPORT_URL": "http://help.ubuntu.com/",
+  "BUG_REPORT_URL": "http://bugs.launchpad.net/ubuntu/"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-trusty.txt-distro-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-trusty.txt-distro-expected.json
@@ -1,0 +1,22 @@
+{
+  "os": "linux",
+  "architecture": null,
+  "name": "Ubuntu",
+  "version": "14.04.4 LTS, Trusty Tahr",
+  "identifier": "ubuntu",
+  "id_like": "debian",
+  "version_codename": null,
+  "version_id": "14.04",
+  "pretty_name": "Ubuntu 14.04.4 LTS",
+  "cpe_name": null,
+  "home_url": "http://www.ubuntu.com/",
+  "documentation_url": null,
+  "support_url": "http://help.ubuntu.com/",
+  "bug_report_url": "http://bugs.launchpad.net/ubuntu/",
+  "privacy_policy_url": null,
+  "build_id": null,
+  "variant": null,
+  "variant_id": null,
+  "logo": null,
+  "extra_data": {}
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-trusty.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-trusty.txt-expected.json
@@ -1,0 +1,11 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "14.04.4 LTS, Trusty Tahr",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 14.04.4 LTS",
+  "VERSION_ID": "14.04",
+  "HOME_URL": "http://www.ubuntu.com/",
+  "SUPPORT_URL": "http://help.ubuntu.com/",
+  "BUG_REPORT_URL": "http://bugs.launchpad.net/ubuntu/"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-utopic.txt-distro-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-utopic.txt-distro-expected.json
@@ -1,0 +1,22 @@
+{
+  "os": "linux",
+  "architecture": null,
+  "name": "Ubuntu",
+  "version": "14.10 (Utopic Unicorn)",
+  "identifier": "ubuntu",
+  "id_like": "debian",
+  "version_codename": null,
+  "version_id": "14.10",
+  "pretty_name": "Ubuntu 14.10",
+  "cpe_name": null,
+  "home_url": "http://www.ubuntu.com/",
+  "documentation_url": null,
+  "support_url": "http://help.ubuntu.com/",
+  "bug_report_url": "http://bugs.launchpad.net/ubuntu/",
+  "privacy_policy_url": null,
+  "build_id": null,
+  "variant": null,
+  "variant_id": null,
+  "logo": null,
+  "extra_data": {}
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-utopic.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-utopic.txt-expected.json
@@ -1,0 +1,11 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "14.10 (Utopic Unicorn)",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 14.10",
+  "VERSION_ID": "14.10",
+  "HOME_URL": "http://www.ubuntu.com/",
+  "SUPPORT_URL": "http://help.ubuntu.com/",
+  "BUG_REPORT_URL": "http://bugs.launchpad.net/ubuntu/"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-vivid.txt-distro-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-vivid.txt-distro-expected.json
@@ -1,0 +1,22 @@
+{
+  "os": "linux",
+  "architecture": null,
+  "name": "Ubuntu",
+  "version": "15.04 (Vivid Vervet)",
+  "identifier": "ubuntu",
+  "id_like": "debian",
+  "version_codename": null,
+  "version_id": "15.04",
+  "pretty_name": "Ubuntu 15.04",
+  "cpe_name": null,
+  "home_url": "http://www.ubuntu.com/",
+  "documentation_url": null,
+  "support_url": "http://help.ubuntu.com/",
+  "bug_report_url": "http://bugs.launchpad.net/ubuntu/",
+  "privacy_policy_url": null,
+  "build_id": null,
+  "variant": null,
+  "variant_id": null,
+  "logo": null,
+  "extra_data": {}
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-vivid.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-vivid.txt-expected.json
@@ -1,0 +1,11 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "15.04 (Vivid Vervet)",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 15.04",
+  "VERSION_ID": "15.04",
+  "HOME_URL": "http://www.ubuntu.com/",
+  "SUPPORT_URL": "http://help.ubuntu.com/",
+  "BUG_REPORT_URL": "http://bugs.launchpad.net/ubuntu/"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-wily.txt-distro-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-wily.txt-distro-expected.json
@@ -1,0 +1,22 @@
+{
+  "os": "linux",
+  "architecture": null,
+  "name": "Ubuntu",
+  "version": "15.10 (Wily Werewolf)",
+  "identifier": "ubuntu",
+  "id_like": "debian",
+  "version_codename": null,
+  "version_id": "15.10",
+  "pretty_name": "Ubuntu 15.10",
+  "cpe_name": null,
+  "home_url": "http://www.ubuntu.com/",
+  "documentation_url": null,
+  "support_url": "http://help.ubuntu.com/",
+  "bug_report_url": "http://bugs.launchpad.net/ubuntu/",
+  "privacy_policy_url": null,
+  "build_id": null,
+  "variant": null,
+  "variant_id": null,
+  "logo": null,
+  "extra_data": {}
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-wily.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-wily.txt-expected.json
@@ -1,0 +1,11 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "15.10 (Wily Werewolf)",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 15.10",
+  "VERSION_ID": "15.10",
+  "HOME_URL": "http://www.ubuntu.com/",
+  "SUPPORT_URL": "http://help.ubuntu.com/",
+  "BUG_REPORT_URL": "http://bugs.launchpad.net/ubuntu/"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-xenial.txt-distro-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-xenial.txt-distro-expected.json
@@ -1,0 +1,24 @@
+{
+  "os": "linux",
+  "architecture": null,
+  "name": "Ubuntu",
+  "version": "16.04 LTS (Xenial Xerus)",
+  "identifier": "ubuntu",
+  "id_like": "debian",
+  "version_codename": null,
+  "version_id": "16.04",
+  "pretty_name": "Ubuntu 16.04 LTS",
+  "cpe_name": null,
+  "home_url": "http://www.ubuntu.com/",
+  "documentation_url": null,
+  "support_url": "http://help.ubuntu.com/",
+  "bug_report_url": "http://bugs.launchpad.net/ubuntu/",
+  "privacy_policy_url": null,
+  "build_id": null,
+  "variant": null,
+  "variant_id": null,
+  "logo": null,
+  "extra_data": {
+    "UBUNTU_CODENAME": "xenial"
+  }
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-xenial.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-xenial.txt-expected.json
@@ -1,0 +1,12 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "16.04 LTS (Xenial Xerus)",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 16.04 LTS",
+  "VERSION_ID": "16.04",
+  "HOME_URL": "http://www.ubuntu.com/",
+  "SUPPORT_URL": "http://help.ubuntu.com/",
+  "BUG_REPORT_URL": "http://bugs.launchpad.net/ubuntu/",
+  "UBUNTU_CODENAME": "xenial"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-yakkety.txt-distro-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-yakkety.txt-distro-expected.json
@@ -1,0 +1,24 @@
+{
+  "os": "linux",
+  "architecture": null,
+  "name": "Ubuntu",
+  "version": "16.10 (Yakkety Yak)",
+  "identifier": "ubuntu",
+  "id_like": "debian",
+  "version_codename": "yakkety",
+  "version_id": "16.10",
+  "pretty_name": "Ubuntu 16.10",
+  "cpe_name": null,
+  "home_url": "http://www.ubuntu.com/",
+  "documentation_url": null,
+  "support_url": "http://help.ubuntu.com/",
+  "bug_report_url": "http://bugs.launchpad.net/ubuntu/",
+  "privacy_policy_url": "http://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "build_id": null,
+  "variant": null,
+  "variant_id": null,
+  "logo": null,
+  "extra_data": {
+    "UBUNTU_CODENAME": "yakkety"
+  }
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-yakkety.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-yakkety.txt-expected.json
@@ -1,0 +1,14 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "16.10 (Yakkety Yak)",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 16.10",
+  "VERSION_ID": "16.10",
+  "HOME_URL": "http://www.ubuntu.com/",
+  "SUPPORT_URL": "http://help.ubuntu.com/",
+  "BUG_REPORT_URL": "http://bugs.launchpad.net/ubuntu/",
+  "PRIVACY_POLICY_URL": "http://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "VERSION_CODENAME": "yakkety",
+  "UBUNTU_CODENAME": "yakkety"
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-zesty.txt-distro-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-zesty.txt-distro-expected.json
@@ -1,0 +1,24 @@
+{
+  "os": "linux",
+  "architecture": null,
+  "name": "Ubuntu",
+  "version": "17.04 (Zesty Zapus)",
+  "identifier": "ubuntu",
+  "id_like": "debian",
+  "version_codename": "zesty",
+  "version_id": "17.04",
+  "pretty_name": "Ubuntu 17.04",
+  "cpe_name": null,
+  "home_url": "https://www.ubuntu.com/",
+  "documentation_url": null,
+  "support_url": "https://help.ubuntu.com/",
+  "bug_report_url": "https://bugs.launchpad.net/ubuntu/",
+  "privacy_policy_url": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "build_id": null,
+  "variant": null,
+  "variant_id": null,
+  "logo": null,
+  "extra_data": {
+    "UBUNTU_CODENAME": "zesty"
+  }
+}

--- a/tests/data/distro/os-release/ubuntu/ubuntu-zesty.txt-expected.json
+++ b/tests/data/distro/os-release/ubuntu/ubuntu-zesty.txt-expected.json
@@ -1,0 +1,14 @@
+{
+  "NAME": "Ubuntu",
+  "VERSION": "17.04 (Zesty Zapus)",
+  "ID": "ubuntu",
+  "ID_LIKE": "debian",
+  "PRETTY_NAME": "Ubuntu 17.04",
+  "VERSION_ID": "17.04",
+  "HOME_URL": "https://www.ubuntu.com/",
+  "SUPPORT_URL": "https://help.ubuntu.com/",
+  "BUG_REPORT_URL": "https://bugs.launchpad.net/ubuntu/",
+  "PRIVACY_POLICY_URL": "https://www.ubuntu.com/legal/terms-and-policies/privacy-policy",
+  "VERSION_CODENAME": "zesty",
+  "UBUNTU_CODENAME": "zesty"
+}


### PR DESCRIPTION
Fixes #47

Summary:
- add missing Ubuntu os-release parse fixtures used by `parse_os_release` tests
- add missing Ubuntu LTS os-release sample files used by existing codename symlinks
- add matching distro expected fixtures for Ubuntu codename aliases

Validation:
- Not run locally
- `git diff --check HEAD~1..HEAD`
- Static fixture consistency checks: Ubuntu samples have parse and distro expected fixtures, JSON fixtures parse successfully, symlink targets exist, and generated parse/distro fixture data matches the os-release samples
- Remote CI: Azure `aboutcode-org.container-inspector` build 18871 passed; DCO passed