### PR TITLE
Detect lowercase prefixed Dockerfile names

### DIFF
--- a/src/container_inspector/dockerfile.py
+++ b/src/container_inspector/dockerfile.py
@@ -32,7 +32,7 @@ def get_dockerfile(location):
     otherwise return None.
     """
     fn = path.basename(location)
-    if not "Dockerfile" in fn:
+    if "dockerfile" not in fn.lower():
         return {}
 
     if TRACE:
@@ -43,27 +43,28 @@ def get_dockerfile(location):
         # assign the comments before an instruction line to a line "comment" attribute
         # assign end of line comment to the line
         # assign top of file and  end of file comments to file level comment attribute
-        df = dockerfile_parse.DockerfileParser(location)
+        with open(location, "rb") as df_file:
+            df = dockerfile_parse.DockerfileParser(fileobj=df_file)
 
-        df_data = dict()
-        df_data["location"] = location
-        df_data["base_image"] = df.baseimage
-        df_data["instructions"] = []
+            df_data = dict()
+            df_data["location"] = location
+            df_data["base_image"] = df.baseimage
+            df_data["instructions"] = []
 
-        for entry in df.structure:
-            entry = dict(
-                [
-                    (k, v)
-                    for k, v in sorted(entry.items())
-                    if k
-                    in (
-                        "instruction",
-                        "startline",
-                        "value",
-                    )
-                ]
-            )
-            df_data["instructions"].append(entry)
+            for entry in df.structure:
+                entry = dict(
+                    [
+                        (k, v)
+                        for k, v in sorted(entry.items())
+                        if k
+                        in (
+                            "instruction",
+                            "startline",
+                            "value",
+                        )
+                    ]
+                )
+                df_data["instructions"].append(entry)
         return {location: df_data}
     except:
         if TRACE:

--- a/tests/data/dockerfiles/container-inspector.dockerfile
+++ b/tests/data/dockerfiles/container-inspector.dockerfile
@@ -1,0 +1,2 @@
+FROM alpine:3.20
+RUN echo hello

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -10,11 +10,22 @@ import os
 
 from commoncode.testcase import FileBasedTesting
 
+from container_inspector.dockerfile import get_dockerfile
 from container_inspector.dockerfile import normalized_layer_command
 
 
 class TestDockerfile(FileBasedTesting):
     test_data_dir = os.path.join(os.path.dirname(__file__), "data")
+
+    def test_get_dockerfile_accepts_lowercase_prefixed_dockerfile_name(self):
+        test_file = os.path.join(
+            self.test_data_dir,
+            "dockerfiles",
+            "container-inspector.dockerfile",
+        )
+        dockerfiles = get_dockerfile(test_file)
+        assert test_file in dockerfiles
+        assert "alpine:3.20" == dockerfiles[test_file]["base_image"]
 
     def test_normalized_layer_command(self):
         # tuple of command and expected result tuples


### PR DESCRIPTION
Fixes #37

Summary:
- make Dockerfile candidate detection case-insensitive so prefixed lowercase names such as `container-inspector.dockerfile` are scanned
- parse Dockerfiles through a file object so custom Dockerfile filenames are handled by `dockerfile-parse`
- add a regression fixture and test for a lowercase prefixed Dockerfile name

Validation:
- Not run locally
- `git diff --check HEAD~1..HEAD`
- `git show --check --stat --oneline HEAD`
- Remote CI: Azure `aboutcode-org.container-inspector` build 18870 passed; DCO passed